### PR TITLE
Fetch 5xx and total error rates from graphite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+output/

--- a/Pipfile
+++ b/Pipfile
@@ -16,4 +16,4 @@ requests = "*"
 
 [requires]
 
-python_version = "3.6"
+python_full_version = "3.4.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "33a0ec7c8e3bae6f62dd618f847de92ece20e2bd4efb496927e2524b9c7b8df8"
+            "sha256": "857f1c5f538f56a6f4f35619193931db7b19ebe40ad965b0b72c6523a87525e8"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -18,7 +18,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_full_version": "3.4.3"
         },
         "sources": [
             {

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # GOV.UK App performance summary
 
-Extracts error rate information from graphite
+Extracts error rate information from graphite.
 
 ## Nomenclature
 
-- **Error rate**: The rate of 5xx HTTP responses as a percentage of all
-  responses for an application.
+- **Error count**: The total number of 5xx errors encountered within a 10m window.
+- **Total response count**: The total number of responses served within a 10m window.
+- **Error rate**: The error count as a percentage of total responses.
 
 ## Technical documentation
 
@@ -15,9 +16,11 @@ Install dependencies using [pipenv](https://docs.pipenv.org/).
 
 This script assumes the machine running it can access graphite.
 
-### Running the application
-
+### Running the script
 `pipenv run python run_summary.py`
+
+You can check the data quality with:
+`pipenv run lint_data.py output/*.csv`
 
 ## Licence
 

--- a/lint_data.py
+++ b/lint_data.py
@@ -1,0 +1,82 @@
+import csv
+import sys
+from pathlib import Path
+
+fails = []
+
+def success():
+    '''
+    Report a check that passed
+    '''
+    print('.', end='')
+
+
+def fail(msg, file, lineno):
+    '''
+    Report a check that failed
+    '''
+    fails.append(msg + ' ({file} on line {lineno})'.format(file=file, lineno=lineno))
+    print('x', end='')
+
+
+def test_line(time, errors, total, file, lineno):
+    '''
+    Check the numbers look reasonable
+    '''
+    try:
+        errors = float(errors) if errors != '' else 0
+    except ValueError:
+        fail('Errors should be a number or empty string', file=csv_file.name, lineno=i+1)
+        return
+    else:
+        success()
+    try:
+        total = float(total)
+    except ValueError:
+        fail('Total should be a number', file=csv_file.name, lineno=i+1)
+        return
+    else:
+        success()
+
+    if errors <= total:
+        success()
+    else:
+        fail('Errors should be less than or equal to total', file=csv_file.name, lineno=i+1)
+
+    if errors >= 0 and total >= 0:
+        success()
+    else:
+        fail('Counts should be positive', file=csv_file.name, lineno=i+1)
+
+
+csv_files = [Path(path) for path in sys.argv[1:]]
+
+for csv_file in csv_files:
+    with csv_file.open(newline='') as f:
+        reader = csv.reader(f)
+        next(reader)
+        last_time = None
+
+        for i, line in enumerate(reader):
+            time, errors, total = line
+            test_line(time, errors, total, file=csv_file.name, lineno=i+1)
+
+            if last_time is None or (last_time < time):
+                success()
+            else:
+                fail('Timestamps should increase', file=csv_file.name, lineno=i+1)
+
+            last_time = time
+
+        if last_time is not None:
+            success()
+        else:
+            fail('Should have some data points', file=csv_file.name, lineno=1)
+
+print()
+if fails:
+    for fail in fails:
+        print(fail)
+    sys.exit(1)
+else:
+    print('No problems found.')

--- a/run_summary.py
+++ b/run_summary.py
@@ -1,0 +1,169 @@
+import datetime
+import csv
+import os
+import pathlib
+import requests
+from contextlib import contextmanager
+from typing import NamedTuple
+
+# This query combines all different machines and different status codes.
+# This could obscure cases where a particular machine has a much worse error
+# rate than the others, but we want to make sure that all user requests are
+# counted.
+METRIC_PATTERN = 'sum(stats_counts.{host_name}-*_{host_group}.nginx_logs.{app_name}_publishing_service_gov_uk.http_{status})'
+GRAPHITE_URL = os.environ.get('GRAPHITE_URL', 'https://graphite.publishing.service.gov.uk')
+RENDER_URL = GRAPHITE_URL + '/render/?format=csv'
+OUTPUT_HEADERS = ['Timestamp', '5xx Responses', 'Total Responses']
+GRAPHITE_DATE = '%Y%m%d'
+
+class App(NamedTuple):
+    '''
+    An application in graphite
+    '''
+    name: str
+    host_group: str
+    host_name: str
+
+    def response_count_query(self, status='*'):
+        return METRIC_PATTERN.format(
+            host_name=self.host_name,
+            host_group=self.host_group,
+            app_name=self.name,
+            status=status
+        )
+
+
+class ReportingPeriod:
+    '''
+    A graphite time period
+    '''
+    def __init__(self):
+        today = datetime.date.today()
+        date_to = today.replace(day=1) - datetime.timedelta(days=1)
+        date_from = date_to.replace(day=1)
+
+        self.date_from = date_from
+        self.date_to = date_to
+
+    def params(self):
+        return {
+            'from': self.date_from.strftime(GRAPHITE_DATE),
+            'until': self.date_to.strftime(GRAPHITE_DATE)
+        }
+
+    def __str__(self):
+        return f'{self.date_from.strftime(GRAPHITE_DATE)}_{self.date_to.strftime(GRAPHITE_DATE)}'
+
+
+APPS = [
+    App(name='asset-manager', host_name='backend', host_group='backend'),
+    App(name='bouncer', host_name='bouncer', host_group='redirector'),
+    App(name='collections-publisher', host_name='backend', host_group='backend'),
+    App(name='contacts-admin', host_name='backend', host_group='backend'),
+    App(name='content-performance-manager', host_name='backend', host_group='backend'),
+    App(name='content-store', host_name='content-store', host_group='api'),
+    App(name='content-tagger', host_name='backend', host_group='backend'),
+    App(name='email-alert-api', host_name='backend', host_group='backend'),
+    App(name='hmrc-manuals-api', host_name='backend', host_group='backend'),
+    App(name='imminence', host_name='backend', host_group='backend'),
+    App(name='local-links-manager', host_name='backend', host_group='backend'),
+    App(name='manuals-publisher', host_name='backend', host_group='backend'),
+    App(name='mapit', host_name='mapit', host_group='api'),
+    App(name='maslow', host_name='backend', host_group='backend'),
+    App(name='policy-publisher', host_name='backend', host_group='backend'),
+    App(name='publisher', host_name='backend', host_group='backend'),
+    App(name='publishing-api', host_name='publishing-api', host_group='backend'),
+    App(name='release', host_name='backend', host_group='backend'),
+    App(name='rummager', host_name='search', host_group='api'),
+    App(name='search-admin', host_name='backend', host_group='backend'),
+    App(name='short-url-manager', host_name='backend', host_group='backend'),
+    App(name='signon', host_name='backend', host_group='backend'),
+    App(name='specialist-publisher', host_name='backend', host_group='backend'),
+    App(name='support', host_name='backend', host_group='backend'),
+    App(name='support-api', host_name='backend', host_group='backend'),
+    App(name='transition', host_name='backend', host_group='backend'),
+    App(name='travel-advice-publisher', host_name='backend', host_group='backend'),
+    App(name='whitehall-admin', host_name='whitehall-backend', host_group='backend'),
+
+    # Frontend
+    App(name='calculators', host_name='calculators-frontend', host_group='frontend'),
+    App(name='calendars', host_name='calculators-frontend', host_group='frontend'),
+    App(name='government-frontend', host_name='frontend', host_group='frontend'),
+    App(name='info-frontend', host_name='frontend', host_group='frontend'),
+    App(name='manuals-frontend', host_name='frontend', host_group='frontend'),
+    App(name='smartanswers', host_name='calculators-frontend', host_group='frontend'),
+    App(name='whitehall-frontend', host_name='whitehall-frontend', host_group='frontend'),
+    App(name='feedback', host_name='frontend', host_group='frontend'),
+    App(name='finder-frontend', host_name='calculators-frontend', host_group='frontend'),
+    App(name='collections', host_name='frontend', host_group='frontend'),
+    App(name='static', host_name='frontend', host_group='frontend')
+]
+
+
+def get_csv(params):
+    '''
+    Fetch a CSV from the graphite API
+    '''
+    response = requests.get(RENDER_URL, params=params, stream=True)
+    return csv.reader(response.iter_lines(decode_unicode=True), )
+
+
+@contextmanager
+def output_csv(app):
+    '''
+    Create a CSV writer for an app
+    '''
+    outputdir = pathlib.Path('output')
+    outputdir.mkdir(exist_ok=True)
+    filename = app.name + '.csv'
+    full_path = outputdir / filename
+    with full_path.open('w', newline='') as csvfile:
+        yield csv.writer(csvfile)
+
+
+def combine_datasets(error_response, all_response):
+    '''
+    Combine the two CSVs into one data set
+    '''
+    error_row = next(error_response)
+
+    for total_row in all_response:
+        error_timestamp = error_row[1] if error_row else None
+        total_timestamp = total_row[1]
+
+        # Every sample in the totals data should be in the errors data
+        assert (error_row is None) or (error_timestamp <= total_timestamp)
+
+        if error_timestamp == total_timestamp:
+            yield [total_timestamp, error_row[2], total_row[2]]
+
+            # Only iterate the error response if the data matches
+            try:
+                error_row = next(error_response)
+            except StopIteration:
+                error_row = None
+        else:
+            yield [total_timestamp, None, total_row[2]]
+
+
+if __name__ == '__main__':
+    report_month = ReportingPeriod()
+
+    for app in APPS:
+        print(f'Fetching {app} {report_month}')
+
+        # All 5xx responses
+        params = dict(target=app.response_count_query('5*'))
+        params.update(report_month.params())
+        error_response = get_csv(params)
+
+        # All responses
+        params = dict(target=app.response_count_query())
+        params.update(report_month.params())
+        all_response = get_csv(params)
+
+        with output_csv(app) as writer:
+            writer.writerow(OUTPUT_HEADERS)
+
+            for combined_row in combine_datasets(error_response, all_response):
+                writer.writerow(combined_row)

--- a/run_summary.py
+++ b/run_summary.py
@@ -112,7 +112,7 @@ def get_csv(params):
 
 
 @contextmanager
-def output_csv(app):
+def output_csv(app, report_period):
     '''
     Create a CSV writer for an app
     '''
@@ -122,7 +122,11 @@ def output_csv(app):
     except FileExistsError:
         pass
 
-    filename = app.name + '.csv'
+    filename = '{app_name}_{report_period}.csv'.format(
+        app_name=app.name,
+        report_period=report_period
+    )
+
     full_path = outputdir / filename
     with full_path.open('w', newline='') as csvfile:
         yield csv.writer(csvfile)
@@ -173,7 +177,7 @@ if __name__ == '__main__':
         params.update(report_month.params())
         all_response = get_csv(params)
 
-        with output_csv(app) as writer:
+        with output_csv(app, report_month) as writer:
             writer.writerow(OUTPUT_HEADERS)
 
             for combined_row in combine_datasets(error_response, all_response):

--- a/run_summary.py
+++ b/run_summary.py
@@ -138,6 +138,10 @@ def combine_datasets(error_response, all_response):
         error_timestamp = error_row[1] if error_row else None
         total_timestamp = total_row[1]
 
+        if total_row[2] == '':
+            print('warning: no data for {timestamp}'.format(timestamp=total_timestamp))
+            continue
+
         # Every sample in the totals data should be in the errors data
         assert (error_row is None) or (error_timestamp <= total_timestamp)
 


### PR DESCRIPTION
Extract useful data out of graphite and save it as CSV.

We're interested in HTTP errors as a metric because it's comparable across most of our apps, unlike sentry errors or zendesk tickets, which vary depending on reporting behaviour.

This PR fetches the data for the preceding month, for each app. This script is intended to be run from a jenkins job every month.

This is a first step towards automating calculation of overall error rates per application. Currently Liz has to query the graphite API by hand for every app to collate this information. Once I have a proof of concept I'll look at either moving the data to an S3 bucket, or automatically updating a spreadsheet in google drive.

I'm using python rather than ruby because:
- this is a proof of concept
- it's not part of production infrastructure for running the site
- python has a better ecosystem of libraries I'm likely to want to use if I extend this 

The data I'm getting out is grouped into 10m intervals, so the resulting CSVs are very small (~100k each). Example output:

```csv
Timestamp,5xx Responses,Total Responses
2017-12-01 00:10:00,0.0,4464.0
2017-12-01 00:20:00,0.0,4263.0
2017-12-01 00:30:00,0.0,3710.0
2017-12-01 00:40:00,0.0,4193.0
2017-12-01 00:50:00,0.0,4404.0
2017-12-01 01:00:00,0.0,4189.0
2017-12-01 01:10:00,0.0,4101.0
2017-12-01 01:20:00,0.0,4425.0
2017-12-01 01:30:00,0.0,3479.0
2017-12-01 01:40:00,0.0,3940.0
2017-12-01 01:50:00,0.0,3663.0
2017-12-01 02:00:00,0.0,3558.0
2017-12-01 02:10:00,0.0,3863.0
2017-12-01 02:20:00,0.0,3576.0
2017-12-01 02:30:00,0.0,3667.0
2017-12-01 02:40:00,0.0,3167.0
2017-12-01 02:50:00,0.0,3475.0
2017-12-01 03:00:00,0.0,3714.0
2017-12-01 03:10:00,0.0,3526.0
2017-12-01 03:20:00,0.0,3707.0
```

It matters *when* the data is exported, since there are different retention periods for different granularities.

This is defined by [storage-schemas.conf](http://graphite.readthedocs.io/en/latest/config-carbon.html#storage-schemas-conf)

```
[default]
pattern = .*
retentions = 10s:8d,1m:31d,10m:1y,1h:5y
```