### PR TITLE
Aggregate error rates

### DIFF
--- a/pipelines/base.py
+++ b/pipelines/base.py
@@ -18,10 +18,10 @@ class BaseTask(luigi.Task):
         description=("Date interval of report. Defaults to last month.")
     )
 
-    def __init__(self, step_name, *args, **kwargs):
+    def __init__(self, task_name, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.step_name = step_name
+        self.task_name = task_name
         self.segment = None
 
         if self.date_interval is None:
@@ -35,13 +35,16 @@ class BaseTask(luigi.Task):
     def snapshot_target(self):
         return luigi.LocalTarget(
             self.resource_manager.local_output_file_path(
-                step_name=self.step_name,
+                step_name=self.task_name,
                 segment=self.segment
             )
         )
 
-    def save_snapshot(self, data):
-        self.resource_manager.save_snapshot(data, self.step_name, self.segment)
+    def save_snapshot(self, data, step_name):
+        self.resource_manager.save_snapshot(data, self.task_name + '_step_' + step_name, self.segment)
+
+    def save_target_snapshot(self, data):
+        self.resource_manager.save_snapshot(data, self.task_name, self.segment)
 
     def load_from_step(self, step_name, segment=None):
         return self.resource_manager.load_snapshot(step_name, segment=segment)

--- a/pipelines/error_rate_pipeline_extract.py
+++ b/pipelines/error_rate_pipeline_extract.py
@@ -13,7 +13,7 @@ class ErrorRatePipelineExtract(BaseTask):
     )
 
     def __init__(self, *args, **kwargs):
-        super().__init__(step_name='error_rate_extract', *args, **kwargs)
+        super().__init__(task_name='error_rate_extract', *args, **kwargs)
 
         self.segment = self.application
 
@@ -24,15 +24,14 @@ class ErrorRatePipelineExtract(BaseTask):
         step = ProductionErrorRatesSource()
         data = step.get_error_rates_data(self.application, self.closed_date_range)
 
-        # TODO: because the snapshot is the output, reruns of the job can use
-        # invalid data. We should either use something else as the output or
-        # use a different filename until the data has been validated.
-        self.save_snapshot(data)
+        self.save_snapshot(data, 'production_error_rates_source')
 
         step.validate_output(
             data,
             df_name='output from error_rate_extract {}'.format(self.application)
         )
+
+        self.save_target_snapshot(data)
 
 if __name__ == '__main__':
     luigi.run(main_task_cls=ErrorRatePipelineExtract, local_scheduler=True)

--- a/pipelines/error_rate_pipeline_extract.py
+++ b/pipelines/error_rate_pipeline_extract.py
@@ -9,7 +9,8 @@ class ErrorRatePipelineExtract(BaseTask):
     application = luigi.Parameter(
         default='whitehall-admin',
         always_in_help=True,
-        description=("Application to extract error rates for"))
+        description=("Application to extract error rates for")
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(step_name='error_rate_extract', *args, **kwargs)

--- a/pipelines/error_rate_pipeline_load.py
+++ b/pipelines/error_rate_pipeline_load.py
@@ -18,10 +18,10 @@ class ErrorRatePipelineLoad(BaseTask):
         ]
 
     def __init__(self, *args, **kwargs):
-        super().__init__(step_name='error_rate_extract', *args, **kwargs)
+        super().__init__(task_name='error_rate_extract', *args, **kwargs)
 
         self.filename = filename = self.resource_manager.output_file_name(
-            step_name=self.step_name,
+            step_name=self.task_name,
             segment=self.segment
         ).replace('.csv', '')
 

--- a/pipelines/error_rate_pipeline_transform.py
+++ b/pipelines/error_rate_pipeline_transform.py
@@ -1,0 +1,67 @@
+'''
+Extract step for application error rates pipeline
+'''
+import luigi
+from pipeline_steps.aggregate_error_rates import AggregateErrorRates
+from pipeline_steps.drop_rows_with_missing_data import DropRowsWithMissingData
+from error_rate_pipeline_extract import ErrorRatePipelineExtract
+from base import BaseTask
+
+class ErrorRatePipelineTransform(BaseTask):
+    application = luigi.Parameter(
+        default='whitehall-admin',
+        always_in_help=True,
+        description=("Application to extract error rates for")
+    )
+
+    def requires(self):
+        return [
+            ErrorRatePipelineExtract(application=self.application, date_interval=self.date_interval),
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(step_name='error_rate_transform', *args, **kwargs)
+
+        self.segment = self.application
+
+    def output(self):
+        return self.snapshot_target()
+
+    def run(self):
+        df = self.load_from_step('error_rate_extract', self.segment)
+
+        aggregate_step = AggregateErrorRates()
+        drop_missing_data_step = DropRowsWithMissingData()
+
+        drop_missing_data_step.validate_input(
+            df,
+            df_name='input from error_rate_extract {}'.format(self.segment)
+        )
+
+        df = drop_missing_data_step.transform(df)
+
+        # TODO - rewrite snapshotting so it doesn't overwrite the same file
+        # further down.
+        self.save_snapshot(df)
+
+        drop_missing_data_step.validate_output(
+            df,
+            df_name='output from error_rates_transform step 1'
+        )
+
+        aggregate_step.validate_input(
+            df,
+            df_name='input from error_rates_transform step 1'
+        )
+
+        df = aggregate_step.transform(df, self.application, self.closed_date_range)
+        self.save_snapshot(df)
+
+        aggregate_step.validate_output(
+            df,
+            df_name='output from error_rates_transform step 2'
+        )
+
+
+if __name__ == '__main__':
+    luigi.run(main_task_cls=ErrorRatePipelineTransform, local_scheduler=True)

--- a/pipelines/error_rate_pipeline_transform.py
+++ b/pipelines/error_rate_pipeline_transform.py
@@ -20,7 +20,7 @@ class ErrorRatePipelineTransform(BaseTask):
         ]
 
     def __init__(self, *args, **kwargs):
-        super().__init__(step_name='error_rate_transform', *args, **kwargs)
+        super().__init__(task_name='error_rate_transform', *args, **kwargs)
 
         self.segment = self.application
 
@@ -39,10 +39,7 @@ class ErrorRatePipelineTransform(BaseTask):
         )
 
         df = drop_missing_data_step.transform(df)
-
-        # TODO - rewrite snapshotting so it doesn't overwrite the same file
-        # further down.
-        self.save_snapshot(df)
+        self.save_snapshot(df, 'drop_rows_with_missing_data')
 
         drop_missing_data_step.validate_output(
             df,
@@ -55,12 +52,14 @@ class ErrorRatePipelineTransform(BaseTask):
         )
 
         df = aggregate_step.transform(df, self.application, self.closed_date_range)
-        self.save_snapshot(df)
+        self.save_snapshot(df, 'aggregate_error_rates')
 
         aggregate_step.validate_output(
             df,
             df_name='output from error_rates_transform step 2'
         )
+
+        self.save_target_snapshot(df)
 
 
 if __name__ == '__main__':

--- a/pipelines/pipeline_steps/aggregate_error_rates.py
+++ b/pipelines/pipeline_steps/aggregate_error_rates.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import logging
+from pipeline_util.data_frame_validator import DataFrameValidator
+from pipeline_util.time_period import get_date_range_phrase
+
+class AggregateErrorRates:
+    """
+    Sum up HTTP response counts over a time period, and calculate the percentages.
+    """
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+
+    def validate_input(self, data, df_name):
+        validator = DataFrameValidator(df_name)
+        validator.check_column_exists(data, 'timestamp')
+        validator.check_column_exists(data, 'count_total')
+        validator.check_column_exists(data, 'count_error')
+        validator.check_no_empty_values(data, 'timestamp')
+        validator.check_no_empty_values(data, 'count_total')
+        validator.check_no_empty_values(data, 'count_error')
+        validator.check_column_has_unique_values(data, 'timestamp')
+        validator.check_column_increases(data, 'timestamp')
+        validator.check_column_values_greater_than(data, 'count_error', -1)
+        validator.check_a_at_least_b(data, 'count_total', 'count_error')
+
+        self.logger.debug('Input is valid')
+
+    def transform(self, data, app_name, reporting_period):
+        sums = data.filter(items=['count_total', 'count_error']).sum()
+        self.logger.info('Aggregated counts %s', sums)
+
+        data = pd.DataFrame(
+            [[
+                app_name,
+                get_date_range_phrase(reporting_period),
+                sums.count_error,
+                sums.count_total,
+                100 - (sums.count_error * 100 / sums.count_total),
+            ]],
+            columns = ['application', 'reporting_period', 'count_error', 'count_total', 'success_rate']
+        )
+
+        return data
+
+    def validate_output(self, data, df_name):
+        validator = DataFrameValidator(df_name)
+        validator.check_column_exists(data, 'application')
+        validator.check_column_exists(data, 'reporting_period')
+        validator.check_column_exists(data, 'count_total')
+        validator.check_column_exists(data, 'count_error')
+        validator.check_column_exists(data, 'success_rate')
+        validator.check_column_values_within_limits(data, 'success_rate', 0, 100)
+
+        self.logger.debug('Output is valid')

--- a/pipelines/pipeline_steps/drop_rows_with_missing_data.py
+++ b/pipelines/pipeline_steps/drop_rows_with_missing_data.py
@@ -1,0 +1,34 @@
+import logging
+from pipeline_util.data_frame_validator import DataFrameValidator
+
+class DropRowsWithMissingData:
+    """
+    Takes a time series and drops values where any column is missing
+    """
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+
+    def validate_input(self, data, df_name):
+        validator = DataFrameValidator(df_name)
+        validator.check_not_null(data)
+        validator.check_not_empty(data)
+        validator.check_column_exists(data, 'timestamp')
+        validator.check_no_empty_values(data, 'timestamp')
+        self.logger.debug('Input is valid')
+
+    def transform(self, data):
+        before = len(data)
+        data = data.dropna()
+        after = len(data)
+        self.logger.info('Dropped %d rows with missing values', before-after)
+        return data
+
+    def validate_output(self, data, df_name):
+        validator = DataFrameValidator(df_name)
+        validator.check_column_exists(data, 'timestamp')
+        validator.check_no_empty_values(data, 'timestamp')
+
+        for col in data.columns.tolist():
+            validator.check_no_empty_values(data, col)
+
+        self.logger.debug('Output is valid')

--- a/pipelines/pipeline_steps/export_to_google_sheets.py
+++ b/pipelines/pipeline_steps/export_to_google_sheets.py
@@ -34,7 +34,7 @@ class ExportToGoogleSheets:
         wb.share(share_email, role='writer')
 
     def validate_input(self, data, df_name):
-        validator = DataFrameValidator('ExportToGoogleSheets input')
+        validator = DataFrameValidator(df_name)
         validator.check_not_null(data)
         validator.check_not_empty(data)
         self.logger.debug('Input is valid')

--- a/pipelines/pipeline_steps/production_error_rates_source.py
+++ b/pipelines/pipeline_steps/production_error_rates_source.py
@@ -4,7 +4,6 @@ Extract error rate metrics from graphite.
 import logging
 import os
 import pandas as pd
-from pipeline_util.pipeline_configuration import PipelineConfiguration
 from pipeline_util.graphite_extract_utility import GraphiteExtractUtility
 from pipeline_util.glossary import GlossaryBuilder
 from pipeline_util.data_frame_validator import DataFrameValidator

--- a/pipelines/pipeline_util/file_name_utility.py
+++ b/pipelines/pipeline_util/file_name_utility.py
@@ -1,4 +1,5 @@
 from pipeline_util.pipeline_configuration import PipelineConfiguration
+from pipeline_util.time_period import StartEndDatePhraseGenerator
 import datetime as dt
 import dateutil.relativedelta as rd
 
@@ -87,35 +88,3 @@ class FileNameUtility:
         if file_extension is not None:
             file_name = file_name + "." + file_extension
         return file_name.lower()
-
-
-class StartEndDatePhraseGenerator:
-    PERIOD_TYPES = ['daily', 'weekly', 'monthly']
-
-    def get_period_date_range_phrase(self, period_type, end_date=None):
-        start_date = None
-        if period_type == 'daily':
-            start_date = end_date
-        elif period_type == 'weekly':
-            start_date = end_date - rd.relativedelta(weeks=1) + \
-                         rd.relativedelta(days=1)
-        else:
-            # Assume monthly
-            start_date = end_date - rd.relativedelta(months=1) + \
-                         rd.relativedelta(days=1)
-
-        date_range_phrase = self.get_date_range_phrase(start_date, end_date)
-        return date_range_phrase
-
-    def get_date_range_phrase(self, start_date, end_date):
-        phrase = None
-        start_date_phrase = \
-            start_date.strftime(PipelineConfiguration.DATE_OUTPUT_FORMAT)
-        if start_date == end_date:
-            return start_date_phrase
-
-        end_date_phrase = \
-            end_date.strftime(PipelineConfiguration.DATE_OUTPUT_FORMAT)
-        phrase = \
-            start_date_phrase + '_' + end_date_phrase
-        return phrase

--- a/pipelines/pipeline_util/pipeline_configuration.py
+++ b/pipelines/pipeline_util/pipeline_configuration.py
@@ -1,0 +1,11 @@
+class PipelineConfiguration:
+    """
+    Maintains settings which are treated as constants by the rest of
+    the pipeline.  Most of the settings refer to:
+        - which date format should be used for file names and the time
+          stamp format used in logging.
+        - the names of directories that appear when the pipelines are run
+        - standardised parameter values for CSV file processing
+    """
+    DATE_OUTPUT_FORMAT = '%Y-%m-%d'
+    TIME_STAMP_FORMAT = '%b %d, %Y %H.%M.%S'

--- a/pipelines/pipeline_util/pipeline_configuration.py
+++ b/pipelines/pipeline_util/pipeline_configuration.py
@@ -1,11 +1,6 @@
 class PipelineConfiguration:
     """
-    Maintains settings which are treated as constants by the rest of
-    the pipeline.  Most of the settings refer to:
-        - which date format should be used for file names and the time
-          stamp format used in logging.
-        - the names of directories that appear when the pipelines are run
-        - standardised parameter values for CSV file processing
+    Constants used by the rest of the pipeline.
     """
     DATE_OUTPUT_FORMAT = '%Y-%m-%d'
     TIME_STAMP_FORMAT = '%b %d, %Y %H.%M.%S'

--- a/pipelines/pipeline_util/time_period.py
+++ b/pipelines/pipeline_util/time_period.py
@@ -3,6 +3,7 @@ A helper class to represent time periods
 """
 import datetime
 from collections import namedtuple
+from pipeline_util.pipeline_configuration import PipelineConfiguration
 
 DateRange = namedtuple('DateRange', ('start_date', 'end_date',))
 
@@ -13,3 +14,40 @@ def previous_month():
     start_date = end_date.replace(day=1)
 
     return DateRange(start_date=start_date, end_date=end_date)
+
+
+def get_date_range_phrase(time_period):
+    generator = StartEndDatePhraseGenerator()
+    return generator.get_date_range_phrase(time_period.start_date, time_period.end_date)
+
+
+class StartEndDatePhraseGenerator:
+    PERIOD_TYPES = ['daily', 'weekly', 'monthly']
+
+    def get_period_date_range_phrase(self, period_type, end_date=None):
+        start_date = None
+        if period_type == 'daily':
+            start_date = end_date
+        elif period_type == 'weekly':
+            start_date = end_date - rd.relativedelta(weeks=1) + \
+                         rd.relativedelta(days=1)
+        else:
+            # Assume monthly
+            start_date = end_date - rd.relativedelta(months=1) + \
+                         rd.relativedelta(days=1)
+
+        date_range_phrase = self.get_date_range_phrase(start_date, end_date)
+        return date_range_phrase
+
+    def get_date_range_phrase(self, start_date, end_date):
+        phrase = None
+        start_date_phrase = \
+            start_date.strftime(PipelineConfiguration.DATE_OUTPUT_FORMAT)
+        if start_date == end_date:
+            return start_date_phrase
+
+        end_date_phrase = \
+            end_date.strftime(PipelineConfiguration.DATE_OUTPUT_FORMAT)
+        phrase = \
+            start_date_phrase + '_' + end_date_phrase
+        return phrase


### PR DESCRIPTION
This PR is best reviewed commit by commit.

I've added a new transform task that calculates error rates as a percentage of all responses, using the data extracted from graphite. It's per application.

The output of this task will let me build a dataset containing all applications and benchmarks.

So right now the output is something like this:

Application | Success rate
--| --
asset-manager | 99.988%

and the end result will be this (data from last year):

Application | Benchmark | Target |   | April | May | June | July | Aug | Sept | Oct | Nov
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
asset-manager | 99.988% | 99.990% |   | 99.993% | 99.991% | 99.994% | 99.994% | 99.990% | 99.974% | 99.977% | 99.960%
bouncer | 99.988% | 99.990% |   | 100.000% | 100.000% | 99.999% | 100.000% | 100.000% | 99.999% | 100.000% | 99.999%
collections-publisher | 99.962% | 95-99.99% |   | 100.000% | 100.000% | 100.000% | 100.000% | 100.000% | 99.999% | 100.000% | 99.999%
contacts-admin | 99.458% | 95-99.99% |   | 100.000% | 100.000% | 100.000% | 100.000% | 100.000% | 100.000% | 100.000% | 100.000%
content-performance-manager | N/A | 95-99.99% |   | 100.000% | 99.483% | 99.637% | 98.131% | 99.565% | 97.617% | 99.637% | 99.698%
content-store (and API) | 99.998% | 99.999% |   | 99.999% | 100.000% | 100.000% | 100.000% | 100.000% | 100.000% | 100.000% | 100.000%
content-tagger | 98.897% | 95-99.99% |   | 100.000% | 99.380% | 99.772% | 98.334% | 99.649% | 99.574% | 99.254% | 99.822%
email-alert-api | 99.923% | 95-99.99% |   | 99.983% | 100.000% | 100.000% | 99.907% | 99.918% | 99.960% | 96.140% | 99.900%
hmrc-manuals-api | 99.980% | 95-99.99% |   | 99.929% | 99.930% | 99.827% | 99.352% | 99.837% | 99.904% | 99.929% | 100.000%

Resolves https://github.com/alphagov/app-performance-summary/issues/12 